### PR TITLE
set helm install enpoint config option

### DIFF
--- a/charts/karmada-operator/_crds/install.karmada.io_karmadadeployments.yaml
+++ b/charts/karmada-operator/_crds/install.karmada.io_karmadadeployments.yaml
@@ -80,9 +80,11 @@ spec:
                       type: string
                     type: array
                   endPointCfg:
-                    description: the install cluster access credentials, must be support.
-                      there are two way to connect cluster, one is by kubeconfig file
-                      path. two is restore the credentials in the secret.
+                    description: the install cluster access credentials,if not specified,
+                      it will be installed in the cluster where the operator is located
+                      by default. There are two way to connect cluster, one is by
+                      kubeconfig file path. two is restore the credentials in the
+                      secret.
                     properties:
                       controlPlaneEndpoint:
                         description: The API endpoint of the member cluster. This

--- a/examples/karmadaDeployment.yaml
+++ b/examples/karmadaDeployment.yaml
@@ -6,10 +6,6 @@ spec:
   mode: Helm
   controlPlane:
     namespace: karmada-system
-    endPointCfg:
-      secretRef:
-        namespace: default
-        name: karmada-install
     etcd:
       storageMode: hostPath
     modules:

--- a/pkg/apis/install/v1alpha1/type.go
+++ b/pkg/apis/install/v1alpha1/type.go
@@ -112,10 +112,10 @@ type ControlPlaneCfg struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
-	// the install cluster access credentials, must be support. there are two
-	// way to connect cluster, one is by kubeconfig file path. two is restore
+	// the install cluster access credentials,if not specified,
+	// it will be installed in the cluster where the operator is located by default.
+	// There are two way to connect cluster, one is by kubeconfig file path. two is restore
 	// the credentials in the secret.
-	// +required
 	EndPointCfg *EndPointCfg `json:"endPointCfg,omitempty"`
 
 	// For karmada, two types etcd can be used:


### PR DESCRIPTION
The default endpointconfig is empty to install to the current cluster

fix https://github.com/DaoCloud/karmada-operator/issues/22