### PR TITLE
amend delete kmd process

### DIFF
--- a/pkg/controller/installer_controller.go
+++ b/pkg/controller/installer_controller.go
@@ -187,7 +187,7 @@ func (c *Controller) syncHandler(key string) (err error) {
 	kmd, err := c.installStore.Get(name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.ErrorS(err, "failed to get karmadaDeployment from lister", "policy", name)
+			klog.V(4).Infof("kmd has been deleted: %v", key)
 			return nil
 		}
 		return err
@@ -195,7 +195,6 @@ func (c *Controller) syncHandler(key string) (err error) {
 
 	if !kmd.DeletionTimestamp.IsZero() {
 		klog.InfoS("remove karmadaDeployment", "karmadaDeployment", kmd.Name)
-
 		if err := c.factory.SyncWithAction(kmd, factory.UninstallAction); err != nil {
 			return err
 		}
@@ -205,7 +204,6 @@ func (c *Controller) syncHandler(key string) (err error) {
 		if _, err := c.kmdClient.InstallV1alpha1().KarmadaDeployments().Update(context.TODO(), kmd, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
-
 		return nil
 	}
 	// ensure finalizer

--- a/pkg/status/phase.go
+++ b/pkg/status/phase.go
@@ -50,3 +50,28 @@ func SetStatusPhase(client versioned.Interface, kmd *installv1alpha1.KarmadaDepl
 		return
 	})
 }
+
+func SetStatus(client versioned.Interface, kmd *installv1alpha1.KarmadaDeployment) error {
+	firstTry := true
+	status := kmd.Status
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+		if !firstTry {
+			var getErr error
+			kmd, getErr = client.InstallV1alpha1().KarmadaDeployments().
+				Get(context.TODO(), kmd.Name, metav1.GetOptions{})
+
+			if getErr != nil {
+				return getErr
+			}
+		}
+
+		kmd.Status = status
+		kmdc := kmd.DeepCopy()
+
+		_, err = client.InstallV1alpha1().KarmadaDeployments().
+			UpdateStatus(context.TODO(), kmdc, metav1.UpdateOptions{})
+
+		firstTry = false
+		return
+	})
+}


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind feature

fixed summary manager looper is not shoutdown when after deleting kmd.
