### PR TITLE
remove setDefault func and add default values in controller

### DIFF
--- a/pkg/controller/installer_controller.go
+++ b/pkg/controller/installer_controller.go
@@ -21,9 +21,11 @@ import (
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -230,6 +232,13 @@ func (c *Controller) initDefaultValues(kmd *installv1alpha1.KarmadaDeployment) e
 		kmd.SetLabels(kmdLabels)
 		isUpdate = true
 	}
+	if len(kmd.Spec.ControlPlane.Namespace) == 0 {
+		kmd.Spec.ControlPlane.Namespace = kmd.Name + "-" + rand.String(5)
+	}
+	if len(kmd.Spec.ControlPlane.ServiceType) == 0 {
+		kmd.Spec.ControlPlane.ServiceType = corev1.ServiceTypeNodePort
+	}
+
 	// ensure finalizer
 	if !controllerutil.ContainsFinalizer(kmd, ControllerFinalizer) && kmd.DeletionTimestamp.IsZero() {
 		_ = controllerutil.AddFinalizer(kmd, ControllerFinalizer)

--- a/pkg/installer/helm/install.go
+++ b/pkg/installer/helm/install.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
@@ -456,16 +455,6 @@ func (install *installWorkflow) ServicePort() (int32, error) {
 	}
 
 	return port, nil
-}
-
-func SetDefault(kmd *installv1alpha1.KarmadaDeployment) {
-	if len(kmd.Spec.ControlPlane.Namespace) == 0 {
-		kmd.Spec.ControlPlane.Namespace = kmd.Name + "-" + rand.String(5)
-	}
-
-	if len(kmd.Spec.ControlPlane.ServiceType) == 0 {
-		kmd.Spec.ControlPlane.ServiceType = corev1.ServiceTypeNodePort
-	}
 }
 
 func GetKarmadaVersion(kubeconfig []byte) (*version.Info, error) {


### PR DESCRIPTION
Signed-off-by: calvin0327 <wen.chen@daocloud.io>

/kind bug

As we have not webhook to set default value to kmd, so we should to do it on a previous phase like `syncHandler` func.