### PR TITLE
bump version to v0.1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ifeq ($(VERSION), "")
     LATEST_TAG=$(shell git describe --tags --abbrev=8)
     ifeq ($(LATEST_TAG),)
         # Forked repo may not sync tags from upstream, so give it a default tag to make CI happy.
-        VERSION="v0.1.7"
+        VERSION="v0.1.8"
     else
         VERSION=$(LATEST_TAG)
     endif

--- a/charts/karmada-operator/Chart.yaml
+++ b/charts/karmada-operator/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.7"
+appVersion: "v0.1.8"
 
 sources:
   - "https://github.com/DaoCloud/karmada-operator"

--- a/charts/karmada-operator/values.yaml
+++ b/charts/karmada-operator/values.yaml
@@ -48,7 +48,7 @@ operator:
   image:
     registry: release.daocloud.io
     repository: karmada/karmada-operator
-    tag: "v0.1.7"
+    tag: "v0.1.8"
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ##


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

bump karmada operator verion to v0.1.8:  fixed:

* update `serviceType` defaults of karmada apiserver to `ClusterIP`
* fixed karmada summary manager exist error
* optimize karmada operator install workflow